### PR TITLE
nginx init script should fail on config problem

### DIFF
--- a/debian/nginx-common.nginx.init
+++ b/debian/nginx-common.nginx.init
@@ -145,7 +145,7 @@ case "$1" in
 		# Check configuration before stopping nginx
 		if ! test_nginx_config; then
 			log_end_msg 1 # Configuration error
-			exit 0
+			exit 1
 		fi
 
 		do_stop
@@ -175,7 +175,7 @@ case "$1" in
 		# to the administrator.
 		if ! test_nginx_config; then
 			log_end_msg 1 # Configuration error
-			exit 0
+			exit 1
 		fi
 
 		do_reload
@@ -185,6 +185,7 @@ case "$1" in
 		log_daemon_msg "Testing $DESC configuration"
 		test_nginx_config
 		log_end_msg $?
+		exit $?
 		;;
 	status)
 		status_of_proc -p $PID "$DAEMON" "$NAME" && exit 0 || exit $?


### PR DESCRIPTION
Currently nginx init script return 0 if the configuration files is changed, but it should return an error code if the configuration check fails (e.g. this is the same behavior as for the apache init script).