### PR TITLE
Sbuild build fixes

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -21,7 +21,8 @@ Build-Depends: autotools-dev,
                libssl-dev,
                libxslt1-dev,
                po-debconf,
-               zlib1g-dev
+               zlib1g-dev,
+               ca-certificates
 Standards-Version: 3.9.6.0
 Homepage: http://nginx.net
 Vcs-Git: git://anonscm.debian.org/collab-maint/nginx.git

--- a/debian/rules
+++ b/debian/rules
@@ -172,7 +172,7 @@ strip.arch.%:
 config.arch.%:
 	if [ $* = extras ]; then \
 		cd $(MODULESDIR)/ngx_pagespeed && \
-		curl https://dl.google.com/dl/page-speed/psol/1.9.32.4.tar.gz | tar xz && \
+		curl --cacert /etc/ssl/certs/ca-certificates.crt https://dl.google.com/dl/page-speed/psol/1.9.32.4.tar.gz | tar xz && \
 		perl -pi -e 'print "#ifdef LOG_INFO\n#undef LOG_INFO\n#endif\n\n#ifdef LOG_WARNING\n#undef LOG_WARNING\n#endif\n\n" if $$. == 1' \
 		psol/include/third_party/chromium/src/base/logging.h; \
 	fi

--- a/debian/source/include-binaries
+++ b/debian/source/include-binaries
@@ -1,1 +1,7 @@
 debian/modules/nginx-upload-progress/test/100
+debian/modules/nginx-rtmp-module/test/www/bg.jpg                                                                                        
+debian/modules/nginx-rtmp-module/test/www/jwplayer/jwplayer.flash.swf  
+debian/modules/nginx-rtmp-module/test/www/jwplayer_old/player.swf     
+debian/modules/nginx-rtmp-module/test/rtmp-publisher/RtmpPlayerLight.swf
+debian/modules/nginx-rtmp-module/test/rtmp-publisher/RtmpPlayer.swf                
+debian/modules/nginx-rtmp-module/test/rtmp-publisher/RtmpPublisher.swf


### PR DESCRIPTION
- fix certificates curl call
- add missing binaries required by rtmp-publisher

Signed-off-by: Aurelien ROUGEMONT beorn@gandi.net
